### PR TITLE
tweaks: Split WoW lens into more manageable parts

### DIFF
--- a/lenses/wow/wow.ron
+++ b/lenses/wow/wow.ron
@@ -1,8 +1,9 @@
 (
     version: "1",
     name: "wow",
+    label: "World of Warcraft (WoW) Guides & General Info",
     author: "Chicken",
-    description: Some("Everything World of Warcraft (WoW) related. Search through achievements, classes, items, npcs, spells, and more!"),
+    description: Some("Search through achievements, classes, and more! This includes everything but items, NPCs, and quests."),
     is_enabled: true,
     domains: [],
     urls: [
@@ -18,22 +19,14 @@
         "https://www.wowhead.com/garrisons",
         "https://www.wowhead.com/hunter-pets",
         "https://www.wowhead.com/icons",
-        "https://www.wowhead.com/item-sets",
-        "https://www.wowhead.com/items",
         "https://www.wowhead.com/maps",
-        "https://www.wowhead.com/npcs",
         "https://www.wowhead.com/objects",
         "https://www.wowhead.com/outfits",
-        "https://www.wowhead.com/quests",
         "https://www.wowhead.com/races",
         "https://www.wowhead.com/resources",
-        "https://www.wowhead.com/skills",
         "https://www.wowhead.com/sounds",
-        "https://www.wowhead.com/spells",
         "https://www.wowhead.com/storylines",
         "https://www.wowhead.com/titles",
-        "https://www.wowhead.com/transmog-items",
-        "https://www.wowhead.com/transmog-sets",
         "https://www.wowhead.com/zones",
         // Individual references
         "https://www.wowhead.com/achievement=",
@@ -44,58 +37,10 @@
         "https://www.wowhead.com/currency=",
         // Individual factions
         "https://www.wowhead.com/faction=",
-        // Individual items
-        // NOTE: This broken up like this because of how many items there are and
-        // the limits that the Internet Archive CDX has.
-        "https://www.wowhead.com/item=1",
-        "https://www.wowhead.com/item=2",
-        "https://www.wowhead.com/item=3",
-        "https://www.wowhead.com/item=4",
-        "https://www.wowhead.com/item=5",
-        "https://www.wowhead.com/item=6",
-        "https://www.wowhead.com/item=7",
-        "https://www.wowhead.com/item=8",
-        "https://www.wowhead.com/item=9",
-        // Individual item-sets
-        "https://www.wowhead.com/item-set=",
         "https://www.wowhead.com/pet=",
-        // Individual NPCs
-        "https://www.wowhead.com/npc=1",
-        "https://www.wowhead.com/npc=2",
-        "https://www.wowhead.com/npc=3",
-        "https://www.wowhead.com/npc=4",
-        "https://www.wowhead.com/npc=5",
-        "https://www.wowhead.com/npc=6",
-        "https://www.wowhead.com/npc=7",
-        "https://www.wowhead.com/npc=8",
-        "https://www.wowhead.com/npc=9",
-        "https://www.wowhead.com/skill=",
-        // Individual spells
-        "https://www.wowhead.com/spell=",
-        "https://www.wowhead.com/title=",
-        // Individual quests
-        "https://www.wowhead.com/quest=1",
-        "https://www.wowhead.com/quest=2",
-        "https://www.wowhead.com/quest=3",
-        "https://www.wowhead.com/quest=4",
-        "https://www.wowhead.com/quest=5",
-        "https://www.wowhead.com/quest=6",
-        "https://www.wowhead.com/quest=7",
-        "https://www.wowhead.com/quest=8",
-        "https://www.wowhead.com/quest=9",
         // WoW guides
         "https://www.icy-veins.com/wow/",
     ],
-    rules: [
-        // Ignore filters / notFound pages
-        SkipURL("https://www.wowhead.com/*?*power*"),
-        SkipURL("https://www.wowhead.com/*bonus=*"),
-        SkipURL("https://www.wowhead.com/*filter=*"),
-        SkipURL("https://www.wowhead.com/*ilvl=*"),
-        SkipURL("https://www.wowhead.com/*name:*"),
-        SkipURL("https://www.wowhead.com/*notFound=*"),
-        // Ignore map data
-        SkipURL("https://www.wowhead.com/maps?*data=*"),
-    ]
+    rules: []
 )
 

--- a/lenses/wow_items/wow_items.ron
+++ b/lenses/wow_items/wow_items.ron
@@ -4,7 +4,6 @@
     label: "World of Warcraft (WoW) Items",
     author: "Chicken",
     description: Some("Search through all WoW items and item sets!"),
-    is_enabled: true,
     domains: [],
     urls: [
         "https://www.wowhead.com/item-sets",
@@ -16,4 +15,3 @@
     ],
     rules: []
 )
-

--- a/lenses/wow_items/wow_items.ron
+++ b/lenses/wow_items/wow_items.ron
@@ -1,0 +1,19 @@
+(
+    version: "1",
+    name: "wow_items",
+    label: "World of Warcraft (WoW) Items",
+    author: "Chicken",
+    description: Some("Search through all WoW items and item sets!"),
+    is_enabled: true,
+    domains: [],
+    urls: [
+        "https://www.wowhead.com/item-sets",
+        "https://www.wowhead.com/items",
+        // Individual items
+        "https://www.wowhead.com/item=",
+        // Individual item-sets
+        "https://www.wowhead.com/item-set=",
+    ],
+    rules: []
+)
+

--- a/lenses/wow_npcs/wow_npcs.ron
+++ b/lenses/wow_npcs/wow_npcs.ron
@@ -1,0 +1,13 @@
+(
+    version: "1",
+    name: "wow_npcs",
+    label: "World of Warcraft (WoW) NPCs",
+    author: "Chicken",
+    description: Some("Search through World of Warcraft (WoW) NPCs!"),
+    domains: [],
+    urls: [
+        "https://www.wowhead.com/npcs$",
+        "https://www.wowhead.com/npc=",
+    ],
+    rules: []
+)

--- a/lenses/wow_quests/wow_quests.ron
+++ b/lenses/wow_quests/wow_quests.ron
@@ -1,0 +1,13 @@
+(
+    version: "1",
+    name: "wow_quests",
+    label: "World of Warcraft (WoW) Quests",
+    author: "Chicken",
+    description: Some("Search through all WoW quests!"),
+    domains: [],
+    urls: [
+        "https://www.wowhead.com/quests$",
+        "https://www.wowhead.com/quest=",
+    ],
+    rules: []
+)

--- a/lenses/wow_spells/wow_spells.ron
+++ b/lenses/wow_spells/wow_spells.ron
@@ -1,0 +1,28 @@
+(
+    version: "1",
+    name: "wow_spells",
+    label: "World of Warcraft (WoW) Spells",
+    author: "Chicken",
+    description: Some("Search through World of Warcraft (WoW) spells & abilities!"),
+    is_enabled: true,
+    domains: [],
+    urls: [
+        "https://www.wowhead.com/skills$",
+        "https://www.wowhead.com/spells$",
+        // Individual spells
+        "https://www.wowhead.com/skill=",
+        "https://www.wowhead.com/spell=",
+    ],
+    rules: [
+        // Ignore filters / notFound pages
+        SkipURL("https://www.wowhead.com/*?*power*"),
+        SkipURL("https://www.wowhead.com/*bonus=*"),
+        SkipURL("https://www.wowhead.com/*filter=*"),
+        SkipURL("https://www.wowhead.com/*ilvl=*"),
+        SkipURL("https://www.wowhead.com/*name:*"),
+        SkipURL("https://www.wowhead.com/*notFound=*"),
+        // Ignore map data
+        SkipURL("https://www.wowhead.com/maps?*data=*"),
+    ]
+)
+


### PR DESCRIPTION
The crawl for the current WoW lens is _massive_, totaling over 600k pages. This splits it up into more manageable pieces and allows the user a little more choice in what can be searched.