### PR TITLE
bump unreal engine 5 version to 5.2

### DIFF
--- a/lenses/unreal_5/unreal_5.ron
+++ b/lenses/unreal_5/unreal_5.ron
@@ -2,8 +2,8 @@
     version: "1",
     author: "oparaskos",
     name: "unreal_5",
-    label: "Unreal Engine 5.1 Docs",
-    description: Some("Unreal Engine 5.1 editor/engine documentation"),
+    label: "Unreal Engine 5.2 Docs",
+    description: Some("Unreal Engine 5.2 editor/engine documentation"),
     categories: ["Programming", "Game Development"],
     domains: [],
     urls: [

--- a/lenses/unreal_5/unreal_5.ron
+++ b/lenses/unreal_5/unreal_5.ron
@@ -7,6 +7,6 @@
     categories: ["Programming", "Game Development"],
     domains: [],
     urls: [
-        "https://docs.unrealengine.com/5.1/en-US"
+        "https://docs.unrealengine.com/5.2/en-US"
     ]
 )


### PR DESCRIPTION
hey there, 

i was just browsing through the lenses and saw that the unreal 5 lens still crawls the 5.1 documentation when the newest version is 5.2 by now. It'd be great if that came preindexed :)

This commit just bumps the version from 5.1 -> 5.2

[5.2 docs](https://docs.unrealengine.com/5.2/en-US/)